### PR TITLE
Fix: Specify exceptions in helper functions

### DIFF
--- a/entangled/utils.py
+++ b/entangled/utils.py
@@ -1,4 +1,5 @@
 from django.apps import apps
+from django.db.models import ObjectDoesNotExist
 
 
 def get_related_object(scope, field_name):
@@ -8,7 +9,7 @@ def get_related_object(scope, field_name):
     try:
         Model = apps.get_model(scope[field_name]['model'])
         relobj = Model.objects.get(pk=scope[field_name]['pk'])
-    except:
+    except (ObjectDoesNotExist, LookupError):
         relobj = None
     return relobj
 
@@ -20,6 +21,6 @@ def get_related_queryset(scope, field_name):
     try:
         Model = apps.get_model(scope[field_name]['model'])
         queryset = Model.objects.filter(pk__in=scope[field_name]['p_keys'])
-    except:
+    except LookupError:
         queryset = None
     return queryset


### PR DESCRIPTION
Thanks for this extremely valuable package! This is just a minuscule PR:

Having set up a management command to look for stale references in entangled fields, I came to notice that the helper functions do not specify which exceptions they want to catch. This can lead to unwanted side effects (marking ALL references as stale due to calling the functions with incorrect parameters).

This PR adds the two exceptions which should be caught, afaik:

`ObjectDoesNotExist`: If a `pk` has been removed.

`LookpError`: If a model has been removed or renamed, or the references app has been removed/renamed.