### PR TITLE
Allow initial data to be missing from entangled fields.

### DIFF
--- a/entangled/forms.py
+++ b/entangled/forms.py
@@ -91,7 +91,7 @@ class EntangledModelFormMixin(metaclass=EntangledFormMetaclass):
                     try:
                         for part in opts.retangled_fields[af].split('.'):
                             reference = reference[part]
-                    except KeyError:
+                    except (KeyError, TypeError):
                         continue
                     if isinstance(self.base_fields[af], ModelMultipleChoiceField):
                         try:


### PR DESCRIPTION
Fixes: #13 

Quick fix to allow initial data to be passed into the form even if it is missing the entangled fields.