### PR TITLE
feat: add Django 4.2 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Python application
+name: Run tests
 
 on:
   push:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
-        django-version: ["2.2", "3.2", "4.0"]
+        django-version: ["2.2", "3.2", "4.0", "4.1", "4.2b1"]
         exclude:
           - python-version: 3.9
             django-version: 2.2
@@ -22,6 +22,10 @@ jobs:
             django-version: 2.2
           - python-version: 3.7
             django-version: 4.0
+          - python-version: 3.7
+            django-version: 4.1
+          - python-version: 3.7
+            django-version: "4.2b1"
 
     steps:
     - uses: actions/checkout@v2

--- a/entangled/forms.py
+++ b/entangled/forms.py
@@ -57,7 +57,8 @@ class EntangledFormMetaclass(ModelFormMetaclass):
             fieldset.update(untangled_fields)
             fieldset.update(entangled_fields.keys())
             attrs['Meta'].fields = list(fieldset)
-            attrs['formfield_callback'] = formfield_callback
+            attrs['formfield_callback'] = formfield_callback  # Django up to 4.1
+            attrs['Meta'].formfield_callback = formfield_callback  # Django 4.2 +
         new_class = super().__new__(cls, class_name, bases, attrs)
 
         # perform some model checks


### PR DESCRIPTION
Django 4.2 moves the `formfield_callback` into the Meta class: https://docs.djangoproject.com/en/4.2/releases/4.2/#forms