### PR TITLE
confirm support for Python 3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,5 +51,5 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        python -m pip install beautifulsoup4 lxml pytest pytest-django
+        python -m pip install beautifulsoup4 lxml pytest pytest-django pytest-cov coverage
         python -m pytest -v tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,19 +13,21 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
-        django-version: ["2.2", "3.2", "4.0", "4.1", "4.2b1"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        django-version: ["2.2", "3.2", "4.0", "4.1", "4.2"]
         exclude:
           - python-version: 3.9
             django-version: 2.2
           - python-version: 3.10
+            django-version: 2.2
+          - python-version: 3.11
             django-version: 2.2
           - python-version: 3.7
             django-version: 4.0
           - python-version: 3.7
             django-version: 4.1
           - python-version: 3.7
-            django-version: "4.2b1"
+            django-version: 4.2
 
     steps:
     - uses: actions/checkout@v2
@@ -49,5 +51,5 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        python -m pip install beautifulsoup4 lxml codecov pytest pytest-django
+        python -m pip install beautifulsoup4 lxml pytest pytest-django
         python -m pytest -v tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 - 0.5.4
   * Add support for Django-4.1 and 4.2.
+  * Confirm support for Python 3.11
 
 - 0.5.3
-  * Load external JSONField if used with Django-2.2. 
+  * Load external JSONField if used with Django-2.2.
 
 - 0.5.2
   * Revert "Specify exceptions in helper functions". It introduced

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,6 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = tests.settings
-addopts = --tb=native
+addopts =
+    -v
+    --cov=entangled
+    --tb=native

--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,12 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
     'Framework :: Django :: 2.2',
     'Framework :: Django :: 3.2',
     'Framework :: Django :: 4.0',
+    'Framework :: Django :: 4.1',
+    'Framework :: Django :: 4.2',
 ]
 
 setup(


### PR DESCRIPTION
Adds Python 3.11 and bumps Django to the final version instead of beta.

Tests ran in https://github.com/kviktor/django-entangled/pull/1

Had to remove `codecov` cause it was pulled from pypi (it was deprecated for a while) but it seems like coverage wasn't even run previously https://github.com/jrief/django-entangled/actions/runs/4250666477/jobs/7392049056
Added pytest-cov + coverage instead so there is some information in the output at least.