### PR TITLE
fix: Fields not listed in `entangled_fields` or `untangled_fields` are ignored again

### DIFF
--- a/tests/models.py
+++ b/tests/models.py
@@ -16,5 +16,5 @@ class Product(Model):
         blank=True,
         null=True,
     )
-
+    dummy_field = CharField(max_length=42, blank=True, null=True)
     properties = JSONField()

--- a/tests/test_entangled.py
+++ b/tests/test_entangled.py
@@ -227,3 +227,12 @@ def test_entangled_field_type():
 
 
 
+@pytest.mark.django_db
+def test_no_unlisted_fields():
+    class ProductAdmin(ModelAdmin):
+        form = ProductForm
+
+    print(80*"=")
+    print(ProductForm.base_fields)
+    print(80*"=")
+

--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -156,3 +156,27 @@ def test_multiple_inheritance_sorted():
         features='lxml',
     )
     assert BeautifulSoup(strip_spaces_between_tags(product_form.as_ul()), features='lxml') == expected
+
+
+@pytest.mark.django_db
+def test_form_meta():
+    options = SortedBookForm._meta
+    declared_opt = SortedBookForm.Meta
+
+    assert options.model == Product
+    assert declared_opt.model == Product
+
+    assert not hasattr(declared_opt, 'untangled_fields')
+    assert options.untangled_fields == ['name']
+
+    assert declared_opt.entangled_fields == {'properties': ['author']}
+    assert options.entangled_fields == {
+        'properties': ['active', 'description', 'author']
+    }
+
+    # No retangled fields declared - maps fields onto themselves
+    assert options.retangled_fields ==  {'active': 'active', 'author': 'author', 'description': 'description'}
+
+    assert options.fields == ['name', 'active', 'description', 'author', 'properties']
+
+

--- a/tests/test_modelform_factory.py
+++ b/tests/test_modelform_factory.py
@@ -34,9 +34,10 @@ def test_modelform_entangled_only():
 
 @pytest.mark.django_db
 def test_modelform_exclude_untangled():
-    form = modelform_factory(Product, form=QuantifiedUnsortedProductForm, exclude=('name',))
+    form = modelform_factory(Product, form=QuantifiedUnsortedProductForm, fields="__all__", exclude=('name',))
 
     expected_fields = (
+        'dummy_field',
         'active',
         'description',
         'quantity',
@@ -49,11 +50,12 @@ def test_modelform_exclude_untangled():
 
 
 @pytest.mark.django_db
-def test_modelform_exlude_entangled():
-    form = modelform_factory(Product, form=QuantifiedUnsortedProductForm, exclude=('active',))
+def test_modelform_exclude_entangled():
+    form = modelform_factory(Product, form=QuantifiedUnsortedProductForm, fields="__all__", exclude=('active',))
 
     expected_fields = (
         'name',
+        'dummy_field',
         'description',
         'quantity',
         'unit',


### PR DESCRIPTION
Fixes #25 

* When no `fields` option is given, it does not default to `'__all__'`  but to the fields named in `untangled_fields` and `entangled_fields` (plus the JSON fields)
* When inheriting fields, the order of the `untangled_fields` and `entangled_fields` is retained, i.e. subclasses add fields to the end of the lists
* For testing, the `Product` model now has a `dummy_fields` which should not appear in any form (unless, `fields=' __all__'`) is set  
* A test for inheritance of the `entangled_fields` and `unentangled_fields` options has been added