### PR TITLE
fix: Fully exclude unlisted fields

### DIFF
--- a/entangled/forms.py
+++ b/entangled/forms.py
@@ -42,7 +42,7 @@ class EntangledField(Field):
 
 class EntangledFormMetaclass(ModelFormMetaclass):
     def __new__(cls, class_name, bases, attrs):
-        attrs.setdefault("Meta", type("Meta", (), {"fields": forms.ALL_FIELDS}))
+        attrs.setdefault("Meta", type("Meta", (), {}))
         untangled_fields = list(getattr(attrs["Meta"], "untangled_fields", []))
         entangled_fields = deepcopy(getattr(attrs["Meta"], "entangled_fields", {}))
         retangled_fields = deepcopy(getattr(attrs["Meta"], "retangled_fields", {}))

--- a/entangled/forms.py
+++ b/entangled/forms.py
@@ -77,8 +77,7 @@ class EntangledFormMetaclass(ModelFormMetaclass):
                     attrs[field_name] = EntangledField()
                 attrs["Meta"].fields = (
                     fields or
-                    cls._create_fields_option(untangled_fields, entangled_fields, fields_to_delete) or
-                    forms.ALL_FIELDS
+                    cls._create_fields_option(untangled_fields, entangled_fields, fields_to_delete)
                 )
             else:
                 fieldset = list(fields)  # Create a copy

--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -178,5 +178,3 @@ def test_form_meta():
     assert options.retangled_fields ==  {'active': 'active', 'author': 'author', 'description': 'description'}
 
     assert options.fields == ['name', 'active', 'description', 'author', 'properties']
-
-


### PR DESCRIPTION
Remove `Meta.fields` to default to `"__all__"`.